### PR TITLE
Remove dollar signs from copy-pastable shell commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Requires Python 3.6+. Base16 Shell must also be present.
 
 .. code:: shell
 
-    $ pip install base16-shell-preview
+    pip install base16-shell-preview
 
 Usage
 -----
@@ -25,7 +25,7 @@ Before running, ensure that the ``BASE16_SHELL`` environment variable is set to 
 
 .. code::
 
-   $ base16-shell-preview -h
+   base16-shell-preview -h
    usage: base16-shell-preview [-h] [--version] [--sort-bg]
 
    keys:


### PR DESCRIPTION
I hit the "copy" button that Github automatically adds to code blocks in the README, and it copied the `$` symbol with it. :)

Thanks for the awesome tool!